### PR TITLE
cuda-profiler-api v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,5 @@
 arm_variant_type:
 - sbsa
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -168,7 +168,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-profiler-api-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-profiler-api" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_profiler_api/{{ platform }}/cuda_profiler_api-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: c59fe08ba129401df21ccee8ad3ad9037fda045963f62a9bc4f5f74d8d69bbf3  # [linux64]
-  sha256: d49eb397d0271d60a5768c36ee6867b5206ebb39f857f80251751f0943602977  # [aarch64]
-  sha256: 81926cf0c2f1b294e4a5c45b95ac0c65e3a7874933fc6b1b8b66f607ef209235  # [win]
+  sha256: 161eeee80142ea174a79fc4a79490f559933a2346095a16004b642b8b1199881  # [linux64]
+  sha256: 6eba240b9870496c42b471caa2094ad0666701718994e24255421f9ece084f5c  # [aarch64]
+  sha256: cbe9db0f0fb459b15d7313fb1a7f457f972f67c446f9d3faf87c362d78a14440  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-profiler-api" %}
-{% set version = "13.0.85" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_profiler_api/{{ platform }}/cuda_profiler_api-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: dc233d88a5cafa095b197e6246b4c468a4581c128da8f951d67e063cdd6bca4c  # [linux64]
-  sha256: 58c304116de3d184cebcc7d04934bff9d99d2276ff28c46372664bc3fcc32976  # [aarch64]
-  sha256: 38c6c854f325b64e7ca0a8b14e1996dedb5abbb38f3580e5c7744b688abdc56e  # [win]
+  sha256: c59fe08ba129401df21ccee8ad3ad9037fda045963f62a9bc4f5f74d8d69bbf3  # [linux64]
+  sha256: d49eb397d0271d60a5768c36ee6867b5206ebb39f857f80251751f0943602977  # [aarch64]
+  sha256: 81926cf0c2f1b294e4a5c45b95ac0c65e3a7874933fc6b1b8b66f607ef209235  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-profiler-api 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12025](https://anaconda.atlassian.net/browse/PKG-12025) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12025]: https://anaconda.atlassian.net/browse/PKG-12025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ