### PR TITLE
cuda-profiler-api v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+# - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,10 @@
 {% set version = "12.9.79" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -26,8 +24,8 @@ source:
   sha256: b05519f8ce4f02167bfc859358f62eb771d89ac2af3a6952a82317f2af4bc5bd  # [win]
 
 build:
-  number: 1
-  skip: true  # [osx or ppc64le]
+  number: 0
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -52,10 +50,12 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: CUDA Profiler API Headers.
   description: |
     CUDA Profiler API Headers.
   doc_url: https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#range-replay-define-range
+  dev_url: https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#range-replay-define-range
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-profiler-api 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12796](https://anaconda.atlassian.net/browse/PKG-12796) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.

[PKG-12796]: https://anaconda.atlassian.net/browse/PKG-12796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ